### PR TITLE
fix: correct agent count and add missing Sync Coordinator

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -1,6 +1,6 @@
 # Software Engineering Agents
 
-7 specialized agents covering the full software development lifecycle from UX design and architecture to security and DevOps.
+8 specialized agents covering the full software development lifecycle from UX design and architecture to security and DevOps.
 
 ## Available Agents
 
@@ -8,9 +8,10 @@
 - **SE: UX Designer** - User experience design, journey mapping, and accessibility
 - **SE: Architect** - System architecture, design reviews, and ADRs
 - **SE: Security** - Code review, security analysis, and best practices
+- **SE: Tech Writer** - Technical documentation, blogs, and user guides
 - **SE: Responsible AI** - Accessibility compliance, bias prevention, and ethical development
 - **SE: DevOps/CI/CD** - CI/CD pipelines, deployment debugging, and reliability
-- **SE: Tech Writer** - Technical documentation, blogs, and user guides
+- **SE: Sync Coordinator** - Cross-platform agent synchronization for multi-IDE teams
 
 ## Usage
 


### PR DESCRIPTION
## Summary
Fixes critical documentation issue in `.github/agents/README.md`:
- Update agent count from 7 to 8 (correct count)
- Add missing **SE: Sync Coordinator** to agent list

## Context
These issues were identified in PR #11's automated review but the fix commit was pushed after the PR was already merged.

## Changes
- `.github/agents/README.md`:
  - Line 3: "7 specialized agents" → "8 specialized agents"
  - Added: "**SE: Sync Coordinator** - Cross-platform agent synchronization for multi-IDE teams"

## Verification
All 8 agent files exist in `.github/agents/`:
- se-product-manager-advisor.agent.md
- se-ux-ui-designer.agent.md
- se-system-architecture-reviewer.agent.md
- se-code-reviewer.agent.md
- se-technical-writer.agent.md
- se-responsible-ai-code.agent.md
- se-gitops-ci-specialist.agent.md
- se-sync-coordinator.agent.md ← Was missing from README

🤖 Generated with [Claude Code](https://claude.com/claude-code)